### PR TITLE
Fix "zero sized output" bug

### DIFF
--- a/lib/src/jvmMain/kotlin/ io/github/thibseisel/identikon/IdenticonJvm.kt
+++ b/lib/src/jvmMain/kotlin/ io/github/thibseisel/identikon/IdenticonJvm.kt
@@ -29,5 +29,7 @@ import java.io.OutputStream
 public fun Identicon.saveAsSvg(stream: OutputStream) {
     val renderer = SvgRenderer(size, size)
     render(renderer)
-    renderer.save(stream.bufferedWriter())
+    val br = stream.bufferedWriter()
+    renderer.save(br)
+    br.close()
 }


### PR DESCRIPTION
The example (from readme.md) produces zero sized output. 

// Create a new instance of the Identicon class with an hash string and the given size
val icon = Identicon.fromValue("Hello World!", iconSize = 300)
// Writes the icon to a SVG file
Path("my-icon.svg").outputStream().use {
    icon.saveAsSvg(it)  // Bug in function, doesn't close a bufferedWriter
}

This PR fixes the issue.